### PR TITLE
Switched out Date with LocalDate

### DIFF
--- a/trackr/src/main/java/entities/Anniversary.java
+++ b/trackr/src/main/java/entities/Anniversary.java
@@ -1,6 +1,6 @@
 package entities;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public class Anniversary extends Event{
     /**
@@ -9,7 +9,7 @@ public class Anniversary extends Event{
      * @param date the date this event will take place
      * @param reminderDeadline when this event should be reminded to the user.
      */
-    public Anniversary(Person person, Date date, Date reminderDeadline) {
+    public Anniversary(Person person, LocalDate date, LocalDate reminderDeadline) {
         super(person, date, reminderDeadline);
     }
 
@@ -18,7 +18,7 @@ public class Anniversary extends Event{
      * @param person The person this anniversary is associated with
      * @param date the date this event will take place
      */
-    public Anniversary(Person person, Date date) {
+    public Anniversary(Person person, LocalDate date) {
         this(person, date, null);
     }
 }

--- a/trackr/src/main/java/entities/Birthday.java
+++ b/trackr/src/main/java/entities/Birthday.java
@@ -1,6 +1,6 @@
 package entities;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public class Birthday extends Event{
     /**
@@ -9,7 +9,7 @@ public class Birthday extends Event{
      * @param date the date this event will take place
      * @param reminderDeadline when this event should be reminded to the user.
      */
-    public Birthday(Person person, Date date, Date reminderDeadline) {
+    public Birthday(Person person, LocalDate date, LocalDate reminderDeadline) {
         super(person, date, reminderDeadline);
     }
 
@@ -18,7 +18,7 @@ public class Birthday extends Event{
      * @param person The person this birthday is associated with
      * @param date the date this event will take place
      */
-    public Birthday(Person person, Date date) {
+    public Birthday(Person person, LocalDate date) {
         this(person, date, null);
     }
 }

--- a/trackr/src/main/java/entities/Event.java
+++ b/trackr/src/main/java/entities/Event.java
@@ -1,10 +1,10 @@
 package entities;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public abstract class Event {
-    Date date;
-    Date reminderDeadline;
+    LocalDate date;
+    LocalDate reminderDeadline;
     Person person;
 
     /**
@@ -13,7 +13,7 @@ public abstract class Event {
      * @param date the date this event will take place
      * @param reminderDeadline when this event should be reminded to the user.
      */
-    public Event(Person person, Date date, Date reminderDeadline) {
+    public Event(Person person, LocalDate date, LocalDate reminderDeadline) {
         this.date = date;
         this.reminderDeadline = reminderDeadline;
         this.person = person;
@@ -24,7 +24,7 @@ public abstract class Event {
      * @param person the person associated with this event
      * @param date the date this event will take place
      */
-    public Event(Person person, Date date) {
+    public Event(Person person, LocalDate date) {
         this(person, date, null);
     }
 
@@ -32,7 +32,7 @@ public abstract class Event {
         return person;
     }
 
-    public Date getDate() {
+    public LocalDate getDate() {
         return date;
     }
 
@@ -41,7 +41,7 @@ public abstract class Event {
      * @param date The date to test for a deadline
      * @return A boolean value if the input matches a reminder deadline
      */
-    public boolean isReminderDeadline(Date date) {
+    public boolean isReminderDeadline(LocalDate date) {
         return date.equals(this.reminderDeadline);
     }
 }

--- a/trackr/src/test/java/entities/AnniversaryTest.java
+++ b/trackr/src/test/java/entities/AnniversaryTest.java
@@ -3,7 +3,7 @@ package entities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -15,28 +15,28 @@ class AnniversaryTest {
     void setup() {
         this.anniversary = new Anniversary(
                 new Person("Nopity", "Nope"),
-                new Date(2021, 11, 10),
-                new Date(2021, 11, 5)
+                LocalDate.of(2021, 11, 1),
+                LocalDate.of(2021, 11, 5)
                 );
     }
 
     @Test
     void testReminderDatesTrue() {
-        assertTrue(this.anniversary.isReminderDeadline(new Date(2021, 11, 5)));
+        assertTrue(this.anniversary.isReminderDeadline(LocalDate.of(2021, 11, 5)));
     }
 
     @Test
     void testReminderDatesFalse() {
-        assertFalse(this.anniversary.isReminderDeadline(new Date(2021, 11, 10)));
+        assertFalse(this.anniversary.isReminderDeadline(LocalDate.of(2021, 11, 10)));
     }
 
     @Test
     void testReminderDatesNull() {
         Anniversary anniversary = new Anniversary(
                 new Person("Goodbye"),
-                new Date(2021, 11, 10)
+                LocalDate.of(2021, 11, 10)
                 );
 
-        assertFalse(anniversary.isReminderDeadline(new Date(2021, 11, 10)));
+        assertFalse(anniversary.isReminderDeadline(LocalDate.of(2021, 11, 10)));
     }
 }

--- a/trackr/src/test/java/entities/BirthdayTest.java
+++ b/trackr/src/test/java/entities/BirthdayTest.java
@@ -3,7 +3,7 @@ package entities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,28 +14,28 @@ class BirthdayTest {
     void setup() {
         this.birthday = new Birthday(
                 new Person("Nopity", "Nope"),
-                new Date(2021, 11, 10),
-                new Date(2021, 11, 5)
+                LocalDate.of(2021, 11, 10),
+                LocalDate.of(2021, 11, 5)
                 );
     }
 
     @Test
     void testReminderDatesTrue() {
-        assertTrue(this.birthday.isReminderDeadline(new Date(2021, 11, 5)));
+        assertTrue(this.birthday.isReminderDeadline(LocalDate.of(2021, 11, 5)));
     }
 
     @Test
     void testReminderDatesFalse() {
-        assertFalse(this.birthday.isReminderDeadline(new Date(2021, 11, 10)));
+        assertFalse(this.birthday.isReminderDeadline(LocalDate.of(2021, 11, 10)));
     }
 
     @Test
     void testReminderDatesNull() {
         Birthday birthday = new Birthday(
                 new Person("Geniveve", "King"),
-                new Date(2021, 11, 10)
+                LocalDate.of(2021, 11, 10)
                 );
 
-        assertFalse(birthday.isReminderDeadline(new Date(2021, 11, 10)));
+        assertFalse(birthday.isReminderDeadline(LocalDate.of(2021, 11, 10)));
     }
 }


### PR DESCRIPTION
Before this pull request, the event class used date to store it's own date and it's reminder dates.

However, the non-empty constructors associated with the `Date` class are [depreciated](https://docs.oracle.com/javase/8/docs/api/java/util/Date.html). This makes them a PIA to test, because we'd have to use the [Calendar class](https://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html), 

I considered replacing them with instances of the `Calendar` class, but ultimately felt that would be overkill (and the Java implementation of that class is so convoluted, it's not really worth learning).

What I ended up doing is changing all uses of `Date` to [LocalDate](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html).

Please let me know if this is a bad idea, or if you have any other suggestions for how we can implement concrete dates.