### PR TITLE
Defaulted year to 2008 to prevent leap year errors.

### DIFF
--- a/trackr-app/app/src/main/java/com/trackr/trackr_app/ui/calendar/Calendar.kt
+++ b/trackr-app/app/src/main/java/com/trackr/trackr_app/ui/calendar/Calendar.kt
@@ -114,7 +114,7 @@ fun CalendarMonth(
                         dayOfMonth.toString(),
                         selectedDate.dayOfMonth == dayOfMonth,
                         eventDates.contains(
-                            LocalDate.of(1970,selectedDate.month, dayOfMonth)
+                            LocalDate.of(2008, selectedDate.month, dayOfMonth)
                         ),
                         onSelect
                     )

--- a/trackr-app/app/src/main/java/com/trackr/trackr_app/viewmodels/AddScreenViewModel.kt
+++ b/trackr-app/app/src/main/java/com/trackr/trackr_app/viewmodels/AddScreenViewModel.kt
@@ -171,7 +171,7 @@ class AddScreenViewModel @Inject constructor(
         val newEvent = TrackrEvent(
                 newPerson.id,
                 eventType,
-                eventDate.value.withYear(1970)
+                eventDate.value.withYear(2008)
                     .toEpochDay(),
                 eventDate.value.year,
                 reminderInt,

--- a/trackr-app/app/src/main/java/com/trackr/trackr_app/viewmodels/CalendarViewModel.kt
+++ b/trackr-app/app/src/main/java/com/trackr/trackr_app/viewmodels/CalendarViewModel.kt
@@ -34,8 +34,8 @@ class CalendarViewModel @Inject constructor(
 
     private val eventsThisMonth get() = eventRepository
         .listFromRange(
-            _selectedDate.value.withYear(1970).withDayOfMonth(1),
-            _selectedDate.value.withYear(1970).withDayOfMonth(_selectedDate.value.lengthOfMonth())
+            _selectedDate.value.withYear(2008).withDayOfMonth(1),
+            _selectedDate.value.withYear(2008).withDayOfMonth(_selectedDate.value.lengthOfMonth())
         )
 
     private var _eventDates: MutableLiveData<Set<LocalDate>> = MutableLiveData(HashSet())
@@ -81,8 +81,8 @@ class CalendarViewModel @Inject constructor(
         viewModelScope.launch {
             eventRepository
                 .listFromRange(
-                    _selectedDate.value.withYear(1970),
-                    _selectedDate.value.withYear(1970)
+                    _selectedDate.value.withYear(2008),
+                    _selectedDate.value.withYear(2008)
                 )
                 .collectLatest {
                     val eventsOnSelectedDate = mutableListOf<TrackrEventOutput>()

--- a/trackr-app/app/src/main/java/com/trackr/trackr_app/viewmodels/EditScreenViewModel.kt
+++ b/trackr-app/app/src/main/java/com/trackr/trackr_app/viewmodels/EditScreenViewModel.kt
@@ -158,7 +158,7 @@ class EditScreenViewModel @Inject constructor(
       
         eventRepository.editInterval(reminderInt, event)
         
-        eventRepository.editDate(eventDate.value.withYear(1970), event)
+        eventRepository.editDate(eventDate.value.withYear(2008), event)
 
         eventRepository.editFirstYear(eventDate.value.year, event)
         eventRepository.editType(eventType, event)

--- a/trackr-app/app/src/main/java/com/trackr/trackr_app/viewmodels/HomeScreenViewModel.kt
+++ b/trackr-app/app/src/main/java/com/trackr/trackr_app/viewmodels/HomeScreenViewModel.kt
@@ -53,8 +53,8 @@ class HomeScreenViewModel @Inject constructor(
         }
         viewModelScope.launch {
             eventRepository.listFromRange(
-                LocalDate.now().withYear(1970),
-                LocalDate.now().withYear(1970)
+                LocalDate.now().withYear(2008),
+                LocalDate.now().withYear(2008)
             ).collectLatest {
                 val eventsTodayList = mutableListOf<TrackrEventOutput>()
                 for (event in it) {


### PR DESCRIPTION
Leap years caused app to crash because you can't convert a leap year into a non leap year (1970)