### PR TITLE
Changed Edit Person Icon

### DIFF
--- a/trackr-app/app/src/main/java/com/trackr/trackr_app/ui/home/HomeScreen.kt
+++ b/trackr-app/app/src/main/java/com/trackr/trackr_app/ui/home/HomeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -153,7 +154,7 @@ fun BottomAppBar(
         BottomNavigationItem(
             icon = {
                 Icon(
-                    Icons.Filled.Edit,
+                    Icons.Filled.ManageAccounts,
                     "Edit people",
                     tint = MaterialTheme.colors.onBackground,
                 )


### PR DESCRIPTION
Chose a different icon for edit person to prevent duplicate icons on the home screen.